### PR TITLE
Bundle LICENSE.md with distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md MANIFEST.in README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ name = celery-eternal
 url = http://celery-eternal.readthedocs.io/
 version = 0.1.0
 license = GPL-2+
+license_file = LICENSE.md
 author = Leo Singer
 author_email = leo.singer@ligo.org
 description = Celery task subclass for jobs that should run forever


### PR DESCRIPTION
This PR adds `MANIFEST.in` and patches `setup.cfg` to make sure that `LICENSE.md` is included in distributions, as required to use the GPL.